### PR TITLE
Fix url not sent to backend on th:disabled

### DIFF
--- a/tak-web/src/main/resources/application-dev.properties
+++ b/tak-web/src/main/resources/application-dev.properties
@@ -16,6 +16,8 @@ logging.config=classpath:log4j2-dev.xml
 tak.bestallning.on=true
 tak.bestallning.url.0.name=DEV
 tak.bestallning.url.0.url=http://bs-backend.svc/bs-api/api/takOrders/
+#tak.bestallning.url.1.name=DEV-EXT
+#tak.bestallning.url.1.url=https://dev.ntjp.se/bs-api/api/takorders/
 
 spring.ssl.bundle.pem.bestallning.keystore.private-key=classpath:consumer.key
 spring.ssl.bundle.pem.bestallning.keystore.certificate=classpath:consumer.crt

--- a/tak-web/src/main/resources/templates/bestallning/create.html
+++ b/tak-web/src/main/resources/templates/bestallning/create.html
@@ -38,8 +38,7 @@
         <fieldset class="form">
             <div class="fieldcontain">
                 <label for="url">Källa för hämtning</label>
-                <select name="url" id="url" th:disabled="${#lists.size(bestallningUrlsWithNames) < 2}"
-                        onchange="document.getElementById('selected-url').textContent = this.value; document.getElementById('selected-url').style.display = this.value ? 'inline' : 'none';">
+                <select name="url" id="url" onchange="updateSelectedUrl(this)">
                     <option th:each="entry : *{bestallningUrlsWithNames}"
                             th:value="${entry.url}"
                             th:text="${entry.name}"
@@ -50,21 +49,7 @@
                    th:style="|display: ${#lists.size(bestallningUrlsWithNames) > 0 ? 'inline' : 'none'}|"
                    th:text="${#lists.size(bestallningUrlsWithNames) > 0 ? bestallningUrlsWithNames[0].url : ''}">
                 </p>
-
             </div>
-            <script>
-                document.addEventListener("DOMContentLoaded", function() {
-                    const dropdown = document.getElementById("url");
-                    const selectedOption = dropdown.options[dropdown.selectedIndex];
-                    const selectedUrl = selectedOption ? selectedOption.value : null;
-
-                    if (selectedUrl) {
-                        const selectedUrlElement = document.getElementById("selected-url");
-                        selectedUrlElement.textContent = selectedUrl;
-                        selectedUrlElement.style.display = "inline";
-                    }
-                });
-            </script>
 
             <div class="fieldcontain">
                 <label for="bestallningsNummer">Beställningsnummer</label>
@@ -87,6 +72,22 @@
             <input type="submit" name="validate" value="Granska"/>
         </fieldset>
     </form>
+    <script>
+        function updateSelectedUrl(selectElement) {
+            console.log("updateSelectedUrl: ", selectElement.value)
+            const selectedValue = selectElement.value;
+            const selectedUrlElement = document.getElementById('selected-url');
+            selectedUrlElement.textContent = selectedValue;
+            selectedUrlElement.style.display = selectedValue ? 'inline' : 'none';
+        }
+
+        document.addEventListener("DOMContentLoaded", function () {
+            const dropdown = document.getElementById("url");
+            updateSelectedUrl(dropdown);
+        });
+    </script>
+
+
 </div>
 
 </body>


### PR DESCRIPTION
Removed disabling of the dropdown when less than two urls, because it meant that url was not sent to backend at all.
Now the dropdown will not be disabled at less than two urls.