### PR TITLE
NTU-570: Fix för datumhantering med testfall

### DIFF
--- a/tak-services/src/main/java/se/skltp/tak/services/XmlGregorianCalendarUtil.java
+++ b/tak-services/src/main/java/se/skltp/tak/services/XmlGregorianCalendarUtil.java
@@ -57,10 +57,10 @@ public class XmlGregorianCalendarUtil {
 				theDate.get(Calendar.YEAR),
 				theDate.get(Calendar.MONTH) + 1,
 				theDate.get(Calendar.DATE),
-				theDate.get(Calendar.HOUR_OF_DAY),
-				theDate.get(Calendar.MINUTE),
-				theDate.get(Calendar.SECOND),
-				theDate.get(Calendar.MILLISECOND),
+				DatatypeConstants.FIELD_UNDEFINED,
+				DatatypeConstants.FIELD_UNDEFINED,
+				DatatypeConstants.FIELD_UNDEFINED,
+				DatatypeConstants.FIELD_UNDEFINED,
 				DatatypeConstants.FIELD_UNDEFINED);
 	}
 }

--- a/tak-services/src/test/java/se/skltp/tak/services/XmlGregorianCalendarUtilTest.java
+++ b/tak-services/src/test/java/se/skltp/tak/services/XmlGregorianCalendarUtilTest.java
@@ -20,18 +20,25 @@
  */
 package se.skltp.tak.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Calendar;
 import java.util.Date;
 
+import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class XmlGregorianCalendarUtilTest {
 
+	/**
+	 * The old implementation included time-part info; the new one strips it.
+	 * Comparing raw milliseconds is therefore no longer meaningful.
+	 */
+	@Disabled("fromDate() now returns date-only (time fields = FIELD_UNDEFINED); millisecond comparison is not valid for the new implementation")
 	@Test
 	public void testFromDate() {
 		Date testDate = new Date();
@@ -41,6 +48,85 @@ public class XmlGregorianCalendarUtilTest {
 
 		assertEquals(testDate.getTime(), xmlDate.toGregorianCalendar()
 				.getTime().getTime());
+	}
+
+	// -----------------------------------------------------------------------
+	// Tests for the new date-only implementation of fromDate()
+	// -----------------------------------------------------------------------
+
+	/** Year, month and day must be preserved exactly. */
+	@Test
+	public void testFromDate_preservesYearMonthDay() {
+		Calendar cal = Calendar.getInstance();
+		cal.set(2009, Calendar.MARCH, 9, 0, 0, 0);
+		cal.set(Calendar.MILLISECOND, 0);
+
+		XMLGregorianCalendar xmlDate = XmlGregorianCalendarUtil.fromDate(cal.getTime());
+
+		assertEquals(2009, xmlDate.getYear());
+		assertEquals(3,    xmlDate.getMonth()); // 1-based; not 0-based like Calendar
+		assertEquals(9,    xmlDate.getDay());
+	}
+
+	/** The result must carry NO time information (no T23:00:00.000 in the XML output). */
+	@Test
+	public void testFromDate_hasNoTimePart() {
+		XMLGregorianCalendar xmlDate = XmlGregorianCalendarUtil.fromDate(new Date());
+
+		assertEquals(DatatypeConstants.FIELD_UNDEFINED, xmlDate.getHour());
+		assertEquals(DatatypeConstants.FIELD_UNDEFINED, xmlDate.getMinute());
+		assertEquals(DatatypeConstants.FIELD_UNDEFINED, xmlDate.getSecond());
+		assertEquals(DatatypeConstants.FIELD_UNDEFINED, xmlDate.getMillisecond());
+		assertEquals(DatatypeConstants.FIELD_UNDEFINED, xmlDate.getTimezone());
+	}
+
+	/**
+	 * Hibernate returns java.sql.Date for DATE columns.
+	 * Verify that the day is not shifted back by one when converting.
+	 */
+	@Test
+	public void testFromDate_sqlDate_doesNotShiftDay() {
+		java.sql.Date sqlDate = java.sql.Date.valueOf("2025-09-10");
+
+		XMLGregorianCalendar xmlDate = XmlGregorianCalendarUtil.fromDate(sqlDate);
+
+		assertEquals(2025, xmlDate.getYear());
+		assertEquals(9,    xmlDate.getMonth());
+		assertEquals(10,   xmlDate.getDay());
+	}
+
+	/**
+	 * A Date value late in the evening (e.g. 23:30) must still map to the
+	 * SAME calendar day – not be bumped forward to the next day.
+	 */
+	@Test
+	public void testFromDate_eveningTime_doesNotShiftToNextDay() {
+		Calendar cal = Calendar.getInstance();
+		cal.set(2026, Calendar.MAY, 1, 23, 30, 0);
+		cal.set(Calendar.MILLISECOND, 0);
+
+		XMLGregorianCalendar xmlDate = XmlGregorianCalendarUtil.fromDate(cal.getTime());
+
+		assertEquals(2026, xmlDate.getYear());
+		assertEquals(5,    xmlDate.getMonth());
+		assertEquals(1,    xmlDate.getDay());
+	}
+
+	/**
+	 * A Date value early in the morning (e.g. 00:30) must still map to the
+	 * SAME calendar day – not be bumped back to the previous day.
+	 */
+	@Test
+	public void testFromDate_earlyMorning_doesNotShiftToPreviousDay() {
+		Calendar cal = Calendar.getInstance();
+		cal.set(2026, Calendar.MAY, 1, 0, 30, 0);
+		cal.set(Calendar.MILLISECOND, 0);
+
+		XMLGregorianCalendar xmlDate = XmlGregorianCalendarUtil.fromDate(cal.getTime());
+
+		assertEquals(2026, xmlDate.getYear());
+		assertEquals(5,    xmlDate.getMonth());
+		assertEquals(1,    xmlDate.getDay());
 	}
 
 	@Test

--- a/tak-spring-boot-parent/pom.xml
+++ b/tak-spring-boot-parent/pom.xml
@@ -36,6 +36,12 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Required to run JUnit 4 tests under the JUnit 5 platform (Spring Boot 3 dropped this) -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>


### PR DESCRIPTION
Fix Date Handling in XmlGregorianCalendarUtil.

The XmlGregorianCalendarUtil.fromDate() method was incorrectly including time components (hours, minutes, seconds, milliseconds) when converting java.util.Date to XMLGregorianCalendar. This caused issues with date-only fields stored in the
   database, particularly:

     - Hibernate returns java.sql.Date for DATE columns (which have no time component)
     - Time information was causing date shifts and inconsistencies
     - The serialized XML output included unwanted time parts (e.g., T23:00:00.000)